### PR TITLE
feat: 관심사 분리를 통한 DIP 지키기

### DIFF
--- a/src/main/java/hello/core/AppConfig.java
+++ b/src/main/java/hello/core/AppConfig.java
@@ -1,0 +1,28 @@
+package hello.core;
+
+import hello.core.discount.DiscountPolicy;
+import hello.core.discount.RateDiscountPolicy;
+import hello.core.member.MemberRepository;
+import hello.core.member.MemberService;
+import hello.core.member.MemberServiceImpl;
+import hello.core.member.MemoryMemberRepository;
+import hello.core.order.OrderService;
+import hello.core.order.OrderServiceImpl;
+
+public class AppConfig {
+
+    /**
+     * 역할과 구현 클래스가 한눈에 들어온다.
+     * 생성자를 통한 주입
+     * @return
+     */
+    public MemberService memberService() {
+        return new MemberServiceImpl(new MemoryMemberRepository());
+    }
+
+    public OrderService orderService() {
+        return new OrderServiceImpl(new MemoryMemberRepository(), new RateDiscountPolicy());
+    }
+
+
+}

--- a/src/main/java/hello/core/MemberApp.java
+++ b/src/main/java/hello/core/MemberApp.java
@@ -4,11 +4,13 @@ import hello.core.member.Grade;
 import hello.core.member.Member;
 import hello.core.member.MemberService;
 import hello.core.member.MemberServiceImpl;
+import hello.core.order.OrderService;
 
 public class MemberApp {
     public static void main(String[] args) {
 
-        MemberService memberService = new MemberServiceImpl();
+        AppConfig appConfig = new AppConfig();
+        MemberService memberService = appConfig.memberService();
         Member member = new Member(1L, "memberA", Grade.VIP);
         memberService.join(member);
         Member findMember = memberService.findMember(1L);

--- a/src/main/java/hello/core/OrderApp.java
+++ b/src/main/java/hello/core/OrderApp.java
@@ -10,8 +10,10 @@ import hello.core.order.OrderServiceImpl;
 
 public class OrderApp {
     public static void main(String[] args) {
-        MemberService memberService = new MemberServiceImpl();
-        OrderService orderService = new OrderServiceImpl();
+
+        AppConfig appConfig = new AppConfig();
+        MemberService memberService = appConfig.memberService();
+        OrderService orderService = appConfig.orderService();
 
         Long memberId = 1L;
         Member member = new Member(memberId, "memberA", Grade.VIP);

--- a/src/main/java/hello/core/member/MemberServiceImpl.java
+++ b/src/main/java/hello/core/member/MemberServiceImpl.java
@@ -1,7 +1,11 @@
 package hello.core.member;
 
 public class MemberServiceImpl implements MemberService {
-    private final MemberRepository memberRepository = new MemoryMemberRepository();
+    private final MemberRepository memberRepository;
+
+    public MemberServiceImpl(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
 
     @Override
     public void join(Member member) {

--- a/src/main/java/hello/core/order/OrderServiceImpl.java
+++ b/src/main/java/hello/core/order/OrderServiceImpl.java
@@ -1,15 +1,18 @@
 package hello.core.order;
 
 import hello.core.discount.DiscountPolicy;
-import hello.core.discount.FixDiscountPolicy;
-import hello.core.discount.RateDiscountPolicy;
 import hello.core.member.MemberRepository;
-import hello.core.member.MemoryMemberRepository;
 
 public class OrderServiceImpl implements OrderService {
 
-    private final MemberRepository memberRepository = new MemoryMemberRepository();
-    private final DiscountPolicy discountPolicy = new RateDiscountPolicy();
+    private final MemberRepository memberRepository;
+    private final DiscountPolicy discountPolicy;
+
+    public OrderServiceImpl(MemberRepository memberRepository, DiscountPolicy discountPolicy) {
+        this.memberRepository = memberRepository;
+        this.discountPolicy = discountPolicy;
+    }
+
 
     /*
     단일 책임 원칙을 잘 지킨 설계 방식

--- a/src/test/java/hello/core/member/MemberServiceTest.java
+++ b/src/test/java/hello/core/member/MemberServiceTest.java
@@ -1,9 +1,20 @@
 package hello.core.member;
 
+import hello.core.AppConfig;
+import hello.core.order.OrderService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class MemberServiceTest {
-    MemberService memberService = new MemberServiceImpl();
+
+
+    MemberService memberService;
+
+    @BeforeEach
+    public void beforeEach() {
+        AppConfig appConfig = new AppConfig();
+        memberService = appConfig.memberService();
+    }
 
 
     @Test

--- a/src/test/java/hello/core/order/OrderServiceTest.java
+++ b/src/test/java/hello/core/order/OrderServiceTest.java
@@ -1,16 +1,24 @@
 package hello.core.order;
 
+import hello.core.AppConfig;
 import hello.core.member.Grade;
 import hello.core.member.Member;
 import hello.core.member.MemberService;
-import hello.core.member.MemberServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class OrderServiceTest {
-    MemberService memberService = new MemberServiceImpl();
-    OrderService orderService = new OrderServiceImpl();
+    MemberService memberService;
+    OrderService orderService;
+
+    @BeforeEach
+    public void beforeEach() {
+        AppConfig appConfig = new AppConfig();
+        memberService = appConfig.memberService();
+        orderService = appConfig.orderService();
+    }
 
     @Test
     void createOrder() {


### PR DESCRIPTION
### 관심사 분리

- 애플리케이션에서 각각의 인터페이스를 배우라고 하면, 배우를 선택할지 정하게 하는 기획자가 필요하다. 즉, 관심사 분리를 통해서 본인의 책임에 맞는 기능의 수행에만 집중해야한다.
- 배우는 어떤 배우가 선택되더라도 똑같이 공연할 수 있어야한다.

### 공연 기획자 AppConfig 등장
- 구현 객체를 생성하고 연결하는 별도의 설정 클래스를 통해서, 기획자를 구성해보자

``` java
 public MemberService memberService() {
         return new MemberServiceImpl(new MemoryMemberRepository());
}
     public OrderService orderService() {
         return new OrderServiceImpl(new MemoryMemberRepository(),new FixDiscountPolicy());
}
```
실제 동작에 필요한 구현 객체를 생성하고, 생성한 객체의 인스턴스의 참조를 생성자 주입을 통해 넣어준다.

### 결과

```java
private final MemberRepository memberRepository;
     public MemberServiceImpl(MemberRepository memberRepository) {
         this.memberRepository = memberRepository;
}
```
- 기획자가 직접 주입을 시켜줘서 인터페이스의 구현체에 의존하지 않는다.
- 단지 인터페이스만 의존하도록 변경되었다.
- 생성자를 통해 어떤 구현 객체가 들어올지는 알수 없다. 즉 기획자만 결정할 수 있다.
![스크린샷 2024-06-03 오후 11 37 31](https://github.com/yunhwane/java-playground/assets/147581818/4f8874af-6b24-4ce8-b179-da74680e724b)

- appConfig 객체는 memoryMemberRepository 객체를 생성하고 참조값을 memberServiceImpl을 생성하면서 생성자로 전달한다.
- memberServiceImpl 에 입장에서 생각해보면, 의존관계를 누군가 주입해주는 것 같다고 생각되기 때문에 DI(의존성 주입) 이라고 한다.
- 따라서 우리는 관심사의 분리를 통해 DIP를 지킬 수 있었다.
